### PR TITLE
修復背景色的初始值

### DIFF
--- a/yue.css
+++ b/yue.css
@@ -178,7 +178,7 @@
 .yue pre tt {
   color: #4c4c4c;
   border: none;
-  background-color: none;
+  background-color: transparent;
   padding: 0;
 }
 .yue table {


### PR DESCRIPTION
`background-color` 的初始值是 `transparent`，要想用 `none`，直接使用 `background`
